### PR TITLE
Added a Global Loading Dialog

### DIFF
--- a/src/components/controlPanel/ROMScraper/ROMScraper.js
+++ b/src/components/controlPanel/ROMScraper/ROMScraper.js
@@ -79,11 +79,14 @@ export default class ROMScraper extends Component {
       );
       this.state.controlPanel.hideControlPanel();
     };
-    playROMTask().catch(() => {
+    const playROMPromise = playROMTask();
+    playROMPromise.catch(() => {
       Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
         NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
       );
     });
+
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(playROMPromise);
   }
 
   addROMToCollection() {
@@ -102,11 +105,15 @@ export default class ROMScraper extends Component {
       );
       this.state.controlPanel.hideControlPanel();
     };
-    addROMToCollectionTask().catch(() => {
+    const addROMToCollectionPromise = addROMToCollectionTask();
+    addROMToCollectionPromise.catch(() => {
       Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
         NOTIFICATION_MESSAGES.ERROR_ADD_ROM_TO_COLLECTION
       );
     });
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(
+      addROMToCollectionPromise
+    );
   }
 
   render() {

--- a/src/components/controlPanel/ROMSourceSelector/ROMSourceSelector.js
+++ b/src/components/controlPanel/ROMSourceSelector/ROMSourceSelector.js
@@ -268,6 +268,7 @@ export default class ROMSourceSelector extends Component {
           </button>
         </li>
         <li class="ROMSourceSelector__list__item">
+          {/* mimeTypes, application/zip = .zip, application/octetstream = .gb,.gbc*/}
           <GooglePicker
             clientId={VAPORBOY_GOOGLE_PICKER_CLIENT_ID}
             scope={["https://www.googleapis.com/auth/drive.readonly"]}
@@ -280,6 +281,7 @@ export default class ROMSourceSelector extends Component {
             multiselect={false}
             navHidden={true}
             authImmediate={false}
+            mimeTypes={["application/zip", "application/octet-stream"]}
             viewId={"DOCS"}
           >
             <button>

--- a/src/components/controlPanel/ROMSourceSelector/ROMSourceSelector.js
+++ b/src/components/controlPanel/ROMSourceSelector/ROMSourceSelector.js
@@ -97,11 +97,13 @@ export default class ROMSourceSelector extends Component {
           );
           this.state.controlPanel.hideControlPanel();
         };
-        playROMTask().catch(() => {
+        const playROMPromise = playROMTask();
+        playROMPromise.catch(() => {
           Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
             NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
           );
         });
+        Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(playROMPromise);
       },
       cancelText: "Skip"
     });
@@ -115,77 +117,85 @@ export default class ROMSourceSelector extends Component {
       // Ask if you would like to add to my collection
       this.askToAddROMToCollection(event.target.files[0].name);
     };
-    loadROMTask();
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(loadROMTask());
   }
 
   loadGoogleDriveFile(data) {
-    const loadGoogleDriveFileTask = async () => {
-      if (data.action === "picked") {
-        // Fetch from the drive api to download the file
-        // https://developers.google.com/drive/v3/web/picker
-        // https://developers.google.com/drive/v2/reference/files/get
-
-        const googlePickerFileObject = data.docs[0];
-        const oAuthHeaders = new Headers({
-          Authorization: "Bearer " + googlePickerOAuthToken
-        });
-
-        // First Fetch the Information about the file
-        fetch(
-          "https://www.googleapis.com/drive/v2/files/" +
-            googlePickerFileObject.id,
-          {
-            headers: oAuthHeaders
-          }
-        )
-          .then(response => {
-            return response.json();
-          })
-          .then(responseJson => {
-            if (
-              responseJson.title.endsWith(".zip") ||
-              responseJson.title.endsWith(".gb") ||
-              responseJson.title.endsWith(".gbc")
-            ) {
-              WasmBoy.pause()
-                .then(() => {
-                  // Finally load the file using the oAuthHeaders
-                  WasmBoy.loadROM(responseJson.downloadUrl, {
-                    headers: oAuthHeaders,
-                    fileName: responseJson.title
-                  })
-                    .then(() => {
-                      this.askToAddROMToCollection(responseJson.title);
-                    })
-                    .catch(error => {
-                      console.log("Load Game Error:", error);
-                      Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-                        NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
-                      );
-                    });
-                })
-                .catch(() => {
-                  Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-                    NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
-                  );
-                });
-            } else {
-              this.props.showNotification("Invalid file type. 😞");
-              Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-                NOTIFICATION_MESSAGES.ERROR_FILE_TYPE
-              );
-            }
-          })
-          .catch(error => {
-            Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-              NOTIFICATION_MESSAGES.ERROR_GOOGLE_DRIVE
-            );
-          });
+    const loadGoogleDriveFilePromise = new Promise((resolve, reject) => {
+      // We only want the picked action
+      if (data.action !== "picked") {
+        resolve();
+        return;
       }
-    };
 
+      // Fetch from the drive api to download the file
+      // https://developers.google.com/drive/v3/web/picker
+      // https://developers.google.com/drive/v2/reference/files/get
+
+      const googlePickerFileObject = data.docs[0];
+      const oAuthHeaders = new Headers({
+        Authorization: "Bearer " + googlePickerOAuthToken
+      });
+
+      // First Fetch the Information about the file
+      fetch(
+        "https://www.googleapis.com/drive/v2/files/" +
+          googlePickerFileObject.id,
+        {
+          headers: oAuthHeaders
+        }
+      )
+        .then(response => {
+          return response.json();
+        })
+        .then(responseJson => {
+          if (
+            responseJson.title.endsWith(".zip") ||
+            responseJson.title.endsWith(".gb") ||
+            responseJson.title.endsWith(".gbc")
+          ) {
+            WasmBoy.pause()
+              .then(() => {
+                // Finally load the file using the oAuthHeaders
+                WasmBoy.loadROM(responseJson.downloadUrl, {
+                  headers: oAuthHeaders,
+                  fileName: responseJson.title
+                })
+                  .then(() => {
+                    this.askToAddROMToCollection(responseJson.title);
+                    resolve();
+                  })
+                  .catch(error => {
+                    console.log("Load Game Error:", error);
+                    Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+                      NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
+                    );
+                    reject();
+                  });
+              })
+              .catch(() => {
+                Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+                  NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
+                );
+                reject();
+              });
+          } else {
+            this.props.showNotification("Invalid file type. 😞");
+            Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+              NOTIFICATION_MESSAGES.ERROR_FILE_TYPE
+            );
+            reject();
+          }
+        })
+        .catch(error => {
+          Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+            NOTIFICATION_MESSAGES.ERROR_GOOGLE_DRIVE
+          );
+          reject();
+        });
+    });
     Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(
-      loadGoogleDriveFileTask()
+      loadGoogleDriveFilePromise
     );
   }
 

--- a/src/components/controlPanel/ROMSourceSelector/ROMSourceSelector.js
+++ b/src/components/controlPanel/ROMSourceSelector/ROMSourceSelector.js
@@ -119,68 +119,74 @@ export default class ROMSourceSelector extends Component {
   }
 
   loadGoogleDriveFile(data) {
-    if (data.action === "picked") {
-      // Fetch from the drive api to download the file
-      // https://developers.google.com/drive/v3/web/picker
-      // https://developers.google.com/drive/v2/reference/files/get
+    const loadGoogleDriveFileTask = async () => {
+      if (data.action === "picked") {
+        // Fetch from the drive api to download the file
+        // https://developers.google.com/drive/v3/web/picker
+        // https://developers.google.com/drive/v2/reference/files/get
 
-      const googlePickerFileObject = data.docs[0];
-      const oAuthHeaders = new Headers({
-        Authorization: "Bearer " + googlePickerOAuthToken
-      });
-
-      // First Fetch the Information about the file
-      fetch(
-        "https://www.googleapis.com/drive/v2/files/" +
-          googlePickerFileObject.id,
-        {
-          headers: oAuthHeaders
-        }
-      )
-        .then(response => {
-          return response.json();
-        })
-        .then(responseJson => {
-          if (
-            responseJson.title.endsWith(".zip") ||
-            responseJson.title.endsWith(".gb") ||
-            responseJson.title.endsWith(".gbc")
-          ) {
-            WasmBoy.pause()
-              .then(() => {
-                // Finally load the file using the oAuthHeaders
-                WasmBoy.loadROM(responseJson.downloadUrl, {
-                  headers: oAuthHeaders,
-                  fileName: responseJson.title
-                })
-                  .then(() => {
-                    this.askToAddROMToCollection(responseJson.title);
-                  })
-                  .catch(error => {
-                    console.log("Load Game Error:", error);
-                    Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-                      NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
-                    );
-                  });
-              })
-              .catch(() => {
-                Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-                  NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
-                );
-              });
-          } else {
-            this.props.showNotification("Invalid file type. 😞");
-            Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-              NOTIFICATION_MESSAGES.ERROR_FILE_TYPE
-            );
-          }
-        })
-        .catch(error => {
-          Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-            NOTIFICATION_MESSAGES.ERROR_GOOGLE_DRIVE
-          );
+        const googlePickerFileObject = data.docs[0];
+        const oAuthHeaders = new Headers({
+          Authorization: "Bearer " + googlePickerOAuthToken
         });
-    }
+
+        // First Fetch the Information about the file
+        fetch(
+          "https://www.googleapis.com/drive/v2/files/" +
+            googlePickerFileObject.id,
+          {
+            headers: oAuthHeaders
+          }
+        )
+          .then(response => {
+            return response.json();
+          })
+          .then(responseJson => {
+            if (
+              responseJson.title.endsWith(".zip") ||
+              responseJson.title.endsWith(".gb") ||
+              responseJson.title.endsWith(".gbc")
+            ) {
+              WasmBoy.pause()
+                .then(() => {
+                  // Finally load the file using the oAuthHeaders
+                  WasmBoy.loadROM(responseJson.downloadUrl, {
+                    headers: oAuthHeaders,
+                    fileName: responseJson.title
+                  })
+                    .then(() => {
+                      this.askToAddROMToCollection(responseJson.title);
+                    })
+                    .catch(error => {
+                      console.log("Load Game Error:", error);
+                      Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+                        NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
+                      );
+                    });
+                })
+                .catch(() => {
+                  Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+                    NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
+                  );
+                });
+            } else {
+              this.props.showNotification("Invalid file type. 😞");
+              Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+                NOTIFICATION_MESSAGES.ERROR_FILE_TYPE
+              );
+            }
+          })
+          .catch(error => {
+            Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+              NOTIFICATION_MESSAGES.ERROR_GOOGLE_DRIVE
+            );
+          });
+      }
+    };
+
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(
+      loadGoogleDriveFileTask()
+    );
   }
 
   viewMyCollection() {

--- a/src/components/controlPanel/homebrew/homebrew.js
+++ b/src/components/controlPanel/homebrew/homebrew.js
@@ -36,11 +36,13 @@ export default class Homebrew extends Component {
       this.state.controlPanel.hideControlPanel();
     };
 
-    loadHomebrewTask().catch(() => {
+    const loadHomebrewPromise = loadHomebrewTask();
+    loadHomebrewPromise.catch(() => {
       Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
         NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
       );
     });
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(loadHomebrewPromise);
   }
 
   showHomebrewInfo(game) {

--- a/src/components/controlPanel/loadStateList/loadStateList.js
+++ b/src/components/controlPanel/loadStateList/loadStateList.js
@@ -24,26 +24,33 @@ export default class LoadStateList extends Component {
   }
 
   loadState(saveState) {
-    WasmBoy.loadState(saveState)
-      .then(() => {
-        WasmBoy.play()
-          .then(() => {
-            this.state.controlPanel.hideControlPanel();
-            Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-              NOTIFICATION_MESSAGES.LOAD_STATE
-            );
-          })
-          .catch(() => {
-            Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-              NOTIFICATION_MESSAGES.ERROR_RESUME_ROM
-            );
-          });
-      })
-      .catch(() => {
-        Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
-          NOTIFICATION_MESSAGES.ERROR_LOAD_STATE
-        );
-      });
+    const loadStatePromise = new Promise((resolve, reject) => {
+      WasmBoy.loadState(saveState)
+        .then(() => {
+          WasmBoy.play()
+            .then(() => {
+              this.state.controlPanel.hideControlPanel();
+              Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+                NOTIFICATION_MESSAGES.LOAD_STATE
+              );
+              resolve();
+            })
+            .catch(() => {
+              Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+                NOTIFICATION_MESSAGES.ERROR_RESUME_ROM
+              );
+              reject();
+            });
+        })
+        .catch(() => {
+          Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
+            NOTIFICATION_MESSAGES.ERROR_LOAD_STATE
+          );
+          reject();
+        });
+    });
+
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(loadStatePromise);
   }
 
   render() {

--- a/src/components/controlPanel/myCollection/myCollection.js
+++ b/src/components/controlPanel/myCollection/myCollection.js
@@ -47,11 +47,14 @@ export default class MyCollection extends Component {
       this.state.controlPanel.hideControlPanel();
     };
 
-    loadROMTask().catch(() => {
+    const loadROMPromise = loadROMTask();
+    loadROMPromise.catch(() => {
       Pubx.get(PUBX_CONFIG.NOTIFICATION_KEY).showNotification(
         NOTIFICATION_MESSAGES.ERROR_LOAD_ROM
       );
     });
+
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(loadROMPromise);
   }
 
   editROM(collectionROM) {
@@ -70,7 +73,7 @@ export default class MyCollection extends Component {
         required: true
       });
     };
-    editRomTask();
+    Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(editROMTask());
   }
 
   render() {

--- a/src/components/googlePicker/googlePicker.js
+++ b/src/components/googlePicker/googlePicker.js
@@ -98,7 +98,7 @@ export default class GooglePicker extends Component {
     }
 
     const googleViewId = google.picker.ViewId[this.props.viewId];
-    const view = new window.google.picker.View(googleViewId);
+    const view = new window.google.picker.DocsView(googleViewId);
 
     if (this.props.mimeTypes) {
       view.setMimeTypes(this.props.mimeTypes.join(","));
@@ -107,6 +107,8 @@ export default class GooglePicker extends Component {
     if (!view) {
       throw new Error("Can't find view by viewId");
     }
+
+    view.setMode(window.google.picker.DocsViewMode.LIST);
 
     const picker = new window.google.picker.PickerBuilder()
       .addView(view)
@@ -124,6 +126,19 @@ export default class GooglePicker extends Component {
     if (this.props.multiselect) {
       picker.enableFeature(window.google.picker.Feature.MULTISELECT_ENABLED);
     }
+
+    // Calculate our picker size
+    // https://stackoverflow.com/questions/1248081/get-the-browser-viewport-dimensions-with-javascript
+    // https://developers.google.com/picker/docs/reference#PickerBuilder
+    const viewportWidth = Math.max(
+      document.documentElement.clientWidth,
+      window.innerWidth || 0
+    );
+    const viewportHeight = Math.max(
+      document.documentElement.clientHeight,
+      window.innerHeight || 0
+    );
+    picker.setSize(parseInt(viewportWidth, 10), parseInt(viewportHeight, 10));
 
     picker.build().setVisible(true);
   }

--- a/src/components/loadingModal/loadingModal.js
+++ b/src/components/loadingModal/loadingModal.js
@@ -6,10 +6,110 @@ import { PUBX_CONFIG } from "../../pubx.config";
 export default class LoadingModal extends Component {
   constructor() {
     super();
-    this.setState({});
+    this.setState({
+      loading: {},
+      isActiveClass: "",
+      timeout: false
+    });
+  }
+
+  componentDidMount() {
+    const pubxLoadingSubscriberKey = Pubx.subscribe(
+      PUBX_CONFIG.LOADING_KEY,
+      newState => {
+        // If we added a new promise to the stack, start loading
+        if (
+          this.state.loading.promiseStack.length < newState.promiseStack.length
+        ) {
+          this.startLoading(newState.promiseStack);
+        }
+
+        // Check if the promise stack was cleared
+        if (newState.promiseStack.length <= 0) {
+          this.stopLoading();
+        }
+
+        this.setState({
+          ...this.state,
+          loading: {
+            ...this.state.loading,
+            ...newState
+          }
+        });
+      }
+    );
+
+    this.setState({
+      loading: {
+        ...Pubx.get(PUBX_CONFIG.LOADING_KEY)
+      },
+      pubxLoadingSubscriberKey
+    });
+  }
+
+  componentWillUnmount() {
+    Pubx.unsubscribe(
+      PUBX_CONFIG.LOADING_KEY,
+      this.state.pubxLoadingSubscriberKey
+    );
+  }
+
+  startLoading(promiseStack) {
+    // Check if we are not loading
+    if (!this.state.timeout && !this.state.isActiveClass) {
+      // Wait 400 milliseconds before showing the global loader.
+      // 500 milliseconds is when an app starts to feel laggy
+      this.setState({
+        ...this.state,
+        timeout: setTimeout(() => {
+          this.setState({
+            ...this.state,
+            timeout: false,
+            isActiveClass: "is-active"
+          });
+        }, 400)
+      });
+    }
+
+    // Fire off stop loading once all of our promises resolve
+    Promise.all(promiseStack).then(() => {
+      this.stopLoading();
+    });
+  }
+
+  stopLoading() {
+    if (this.state.timeout) {
+      clearTimeout(this.state.timeout);
+    }
+
+    this.setState({
+      ...this.state,
+      timeout: false,
+      isActiveClass: ""
+    });
   }
 
   render() {
-    return <div class="loading-modal" />;
+    return (
+      <div class={`loading-modal ${this.state.isActiveClass}`}>
+        <div class="loading-modal__modal">
+          <div class="aesthetic-windows-95-modal">
+            <div class="aesthetic-windows-95-modal-title-bar">
+              <div class="aesthetic-windows-95-modal-title-bar-text">
+                Loading...
+              </div>
+            </div>
+
+            <div class="aesthetic-windows-95-modal-content">
+              <div class="aesthetic-windows-95-loader">
+                <div />
+                <div />
+                <div />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 }

--- a/src/components/loadingModal/loadingModal.js
+++ b/src/components/loadingModal/loadingModal.js
@@ -1,0 +1,15 @@
+import { Component } from "preact";
+
+import { Pubx } from "../../services/pubx";
+import { PUBX_CONFIG } from "../../pubx.config";
+
+export default class LoadingModal extends Component {
+  constructor() {
+    super();
+    this.setState({});
+  }
+
+  render() {
+    return <div class="loading-modal" />;
+  }
+}

--- a/src/components/loadingModal/loadingModal.scss
+++ b/src/components/loadingModal/loadingModal.scss
@@ -1,0 +1,2 @@
+.loading-modal {
+}

--- a/src/components/loadingModal/loadingModal.scss
+++ b/src/components/loadingModal/loadingModal.scss
@@ -14,7 +14,7 @@
 
   background-color: rgba(0, 0, 0, 0.5);
 
-  & .is-active {
+  &.is-active {
     display: flex;
   }
 

--- a/src/components/loadingModal/loadingModal.scss
+++ b/src/components/loadingModal/loadingModal.scss
@@ -1,2 +1,53 @@
 .loading-modal {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+
+  width: 100vw;
+  height: 100vh;
+
+  z-index: 7;
+
+  display: none;
+  justify-content: center;
+  align-items: center;
+
+  background-color: rgba(0, 0, 0, 0.5);
+
+  & .is-active {
+    display: flex;
+  }
+
+  &__modal {
+    width: 100%;
+
+    max-width: 400px;
+
+    .aesthetic-windows-95-modal {
+      height: calc(100% - 8px);
+
+      display: flex;
+      flex-direction: column;
+
+      .aesthetic-windows-95-modal-title-bar {
+        width: calc(100% - 10px);
+        min-height: 20px;
+      }
+
+      .aesthetic-windows-95-modal-content {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: column;
+        flex-grow: 1;
+
+        min-height: 100px;
+      }
+    }
+
+    &__content {
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
+  }
 }

--- a/src/components/wasmboyCanvas/wasmboyCanvas.js
+++ b/src/components/wasmboyCanvas/wasmboyCanvas.js
@@ -28,14 +28,14 @@ export default class WasmBoyCanvas extends Component {
     // Check if we are already ready and initialized
     // (this is to avoid resetting a game on layout changes)
     if (!WasmBoy.isReady()) {
-      this.configWasmBoy(canvasElement);
+      const configPromise = this.configWasmBoy(canvasElement);
+      Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(configPromise);
     } else if (WasmBoy.isPlaying()) {
       const setCanvasTask = async () => {
         await WasmBoy.setCanvas(canvasElement);
         await WasmBoy.play();
       };
-
-      setCanvasTask();
+      Pubx.get(PUBX_CONFIG.LOADING_KEY).addPromiseToStack(setCanvasTask());
     }
 
     // Also, subscribe to options/effects changes

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import ControlPanel from "./components/controlPanel/controlPanel";
 import ConfirmationModal from "./components/confirmationModal/confirmationModal";
 import Touchpad from "./components/touchpad/touchpad";
 import Notification from "./components/notification/notification";
+import LoadingModal from "./components/loadingModal/loadingModal";
 
 export default class App extends Component {
   constructor() {
@@ -148,6 +149,7 @@ export default class App extends Component {
         {currentLayout}
         <Touchpad />
         <Notification />
+        <LoadingModal />
       </div>
     );
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,6 +9,7 @@
 @import "../node_modules/aesthetic-css/src/effects/crt";
 @import "../node_modules/aesthetic-css/src/tabs";
 @import "../node_modules/aesthetic-css/src/notification";
+@import "../node_modules/aesthetic-css/src/loading";
 
 // Our re-used styles
 @import "styles/tooltip";

--- a/src/index.scss
+++ b/src/index.scss
@@ -27,6 +27,7 @@
 @import "components/confirmationModal/confirmationModal";
 @import "components/touchpad/touchpad";
 @import "components/notification/notification";
+@import "components/loadingModal/loadingModal";
 
 html,
 body {

--- a/src/pubx.config.js
+++ b/src/pubx.config.js
@@ -18,6 +18,7 @@ export const PUBX_CONFIG = {
   VAPORBOY_OPTIONS_KEY: "VAPORBOY_OPTIONS_KEY",
   VAPORBOY_EFFECTS_KEY: "VAPORBOY_EFFECTS_KEY",
   NOTIFICATION_KEY: "NOTIFICATION_KEY",
+  LOADING_KEY: "LOADING_KEY",
   INITIALIZE: () => {
     initializePubxLayout();
     initializePubxControlPanel();
@@ -26,6 +27,7 @@ export const PUBX_CONFIG = {
     initializePubxVaporBoyOptions();
     initializePubxVaporBoyEffects();
     initializePubxNotification();
+    initializePubxLoading();
   }
 };
 
@@ -203,4 +205,24 @@ const initializePubxNotification = () => {
     }
   };
   Pubx.publish(PUBX_CONFIG.NOTIFICATION_KEY, pubxNotificationState);
+};
+
+const initializePubxLoading = () => {
+  const pubxLoadingState = {
+    promiseStack: [],
+    addPromiseToStack: promise => {
+      Pubx.publish(PUBX_CONFIG.LOADING_KEY, {
+        promiseStack: [
+          ...Pubx.get(PUBX_CONFIG.LOADING_KEY).promiseStack,
+          promise
+        ]
+      });
+    },
+    clearPromiseStack: () => {
+      Pubx.publish(PUBX_CONFIG.LOADING_KEY, {
+        promiseStack: []
+      });
+    }
+  };
+  Pubx.publish(PUBX_CONFIG.LOADING_KEY, pubxLoadingState);
 };


### PR DESCRIPTION
closes #45 

This only shows on Async tasks without an already implemented loading state. This is behind a 250ms timeout. So that it will appear on slower devices/netowkrs for async tasks that take very little time on faster devices.

I mostly expect this to be see/used when downloading a ROM from google drive.

<img width="378" alt="screen shot 2018-08-30 at 1 37 09 am" src="https://user-images.githubusercontent.com/1448289/44840156-58cd8000-abf5-11e8-8467-b39e43f2403d.png">
